### PR TITLE
[fix] 즐겨찾기 등록 해제 시 버그 수정

### DIFF
--- a/front/components/FavoriteContents.js
+++ b/front/components/FavoriteContents.js
@@ -4,9 +4,10 @@ import { FontAwesome } from '@expo/vector-icons';
 import { getEmotionRequire, getWeatherRequire } from '../service/SelectImage';
 import { axios_post } from '../api/api';
 
-export default function FavoriteContents({ diaryId, date, title, weather, emotion, comment, navigation }) {
+export default function FavoriteContents({ diaryId, date, title, weather, emotion, comment, navigation, func }) {
   const cancle = async (id) => {
     await axios_post('favorite', { diaryId: id, liked: false });
+    func();
   };
   const cancleFav = (id) => {
     Alert.alert('즐겨찾기 해제', '즐겨찾기 해제하시겠습니까?', [

--- a/front/pages/Favorite/FavoriteView.js
+++ b/front/pages/Favorite/FavoriteView.js
@@ -6,11 +6,13 @@ import { axios_get } from '../../api/api';
 import styles from './styles';
 import FilterModal from './FilterModal';
 import UserContext from '../../service/UserContext';
+import { useIsFocused } from '@react-navigation/native';
 
 const FavoriteView = ({ navigation }) => {
   const userId = useContext(UserContext).userId;
   const [modalVisible, setModalVisible] = useState(false);
   const [favData, setFavData] = useState([]);
+  const isFocused = useIsFocused();
   const openFilter = () => {
     setModalVisible(true);
   };
@@ -28,8 +30,10 @@ const FavoriteView = ({ navigation }) => {
     }
   };
   useEffect(() => {
-    getFavorData();
-  }, [favData]);
+    if (isFocused) {
+      getFavorData();
+    }
+  }, [isFocused]);
   return (
     <View style={styles.container}>
       <View style={styles.filterView}>
@@ -49,6 +53,7 @@ const FavoriteView = ({ navigation }) => {
               emotion={obj.emotion}
               comment={obj.comment}
               navigation={navigation}
+              func={getFavorData}
             />
           );
         })}


### PR DESCRIPTION
useIsFocused를 활용하여 즐겨찾기 페이지 도달 시 data를 무조건 한 번 받는 것으로 수정

그렇게하여 일기 읽는 창에서의 즐겨찾기 등록/해제 시 바로 반영

즐겨찾기 창에서 즐겨찾기 해제시 바로 반영